### PR TITLE
chore: fix synth destinations, update common templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ If you are still having issues, please include as much information as possible:
    General, Core, and Other are also allowed as types
 2. OS type and version:
 3. Java version:
-4. cloudbuild version(s):
+4. build version(s):
 
 #### Steps to reproduce
 

--- a/.kokoro/continuous/propose_release.sh
+++ b/.kokoro/continuous/propose_release.sh
@@ -22,7 +22,7 @@ if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; th
   # Groom the release PR as new commits are merged.
   npx release-please release-pr --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
     --repo-url=googleapis/java-cloudbuild \
-    --package-name="cloudbuild" \
+    --package-name="build" \
     --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
     --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please \
     --release-type=java-yoshi

--- a/.kokoro/release/bump_snapshot.sh
+++ b/.kokoro/release/bump_snapshot.sh
@@ -22,7 +22,7 @@ if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; th
   # Groom the snapshot release PR immediately after publishing a release
   npx release-please release-pr --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
     --repo-url=googleapis/java-cloudbuild \
-    --package-name="cloudbuild" \
+    --package-name="build" \
     --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
     --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please \
     --snapshot \

--- a/.kokoro/release/drop.cfg
+++ b/.kokoro/release/drop.cfg
@@ -4,6 +4,3 @@ env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
   value: "github/java-cloudbuild/.kokoro/release/drop.sh"
 }
-
-# Download staging properties file.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java/releases/java-cloudbuild"

--- a/.kokoro/release/promote.cfg
+++ b/.kokoro/release/promote.cfg
@@ -4,7 +4,3 @@ env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
   value: "github/java-cloudbuild/.kokoro/release/promote.sh"
 }
-
-# Download staging properties file.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java/releases/java-cloudbuild"
-

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-10-23T07:53:51.111591Z",
+  "updateTime": "2019-10-30T22:07:13.110884Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.40.2",
-        "dockerImage": "googleapis/artman@sha256:3b8f7d9b4c206843ce08053474f5c64ae4d388ff7d995e68b59fb65edf73eeb9"
+        "version": "0.41.0",
+        "dockerImage": "googleapis/artman@sha256:75b38a3b073a7b243545f2332463096624c802bb1e56b8cb6f22ba1ecd325fa9"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0d0dc5172f16c9815a5eda6e99408fb96282f608",
-        "internalRef": "276178557"
+        "sha": "78883c8de959f7a9870c332ab0e3d788b13dd763",
+        "internalRef": "277528057"
       }
     },
     {

--- a/synth.py
+++ b/synth.py
@@ -25,13 +25,23 @@ versions = ['v1']
 config_pattern = '/google/devtools/cloudbuild/artman_cloudbuild.yaml'
 
 for version in versions:
-    java.gapic_library(
+    library = gapic.java_library(
         service=service,
         version=version,
-        config_pattern=config_pattern,
-        package_pattern='com.google.cloudbuild.{version}',
-        gapic=gapic,
-    )
+        config_path=config_pattern.format(version=version),
+        artman_output_name='')
+
+    package_name = f'com.google.cloudbuild.{version}'
+    java.fix_proto_headers(library / f'proto-google-cloud-build-{version}')
+    java.fix_grpc_headers(library / f'grpc-google-cloud-build-{version}', package_name)
+
+    s.copy(library / f'gapic-google-cloud-build-{version}/src', f'google-cloud-build/src')
+    s.copy(library / f'grpc-google-cloud-build-{version}/src', f'grpc-google-cloud-build-{version}/src')
+    s.copy(library / f'proto-google-cloud-build-{version}/src', f'proto-google-cloud-build-{version}/src')
+
+    java.format_code(f'google-cloud-build/src')
+    java.format_code(f'grpc-google-cloud-build-{version}/src')
+    java.format_code(f'proto-google-cloud-build-{version}/src')
 
 common_templates = gcp.CommonTemplates()
 templates = common_templates.java_library()


### PR DESCRIPTION
We renamed the client from cloudbuild to build so we need to adjust where synth moves files.